### PR TITLE
Deprecate support for Appsee iOS due to Apple's

### DIFF
--- a/src/appsee.android.ts
+++ b/src/appsee.android.ts
@@ -3,6 +3,11 @@ import { WebView } from "tns-core-modules/ui/web-view";
 import { View } from "tns-core-modules/ui/core/view";
 
 declare let com: any;
+let packageExists = true;
+if (typeof com.appsee.Appsee === "undefined" || !com.appsee.Appsee) {
+    packageExists = false;
+    console.error("Appsee plugin is not installed correctly!!!");
+}
 
 /* Helper functions */
 function toJavaValue(jsValue: any) {
@@ -59,38 +64,70 @@ function objectToJavaMap(obj: object) {
 
 /* Starting and stopping Appsee monitoring */
 export function setDebug(log: boolean): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Enabling Logcat debugging for Appsee");
     com.appsee.Appsee.setDebugToLogcat(log);
 }
 export function start(apiKey: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Starting Appsee monitoring...");
     com.appsee.Appsee.start(apiKey);
 }
 
 /* Marking views as sensitive */
 export function markViewAsSensitive(view: View): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Marking view as sensitive in Appsee");
     com.appsee.Appsee.markViewAsSensitive(view.android);
 }
 export function unmarkViewAsSensitive(view: View): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Unmarking view as sensitive in Appsee");
     com.appsee.Appsee.unmarkViewAsSensitive(view.android);
 }
 
 /* Labeling events and views in Appsee */
 export function startScreen(screenName: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Starting Appsee screen: " + screenName);
     com.appsee.Appsee.startScreen(screenName);
 }
 export function setUserId(userId: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Setting user ID to: " + userId);
     com.appsee.Appsee.setUserId(userId);
 }
 export function setLocationDescription(description: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Setting location description: " + description);
     com.appsee.Appsee.setLocationDescription(description);
 }
 export function addEvent(eventName: string, properties?: object): void {
+    if (!packageExists) {
+        return;
+    }
+
     if (properties) {
         console.log("Adding event with properties: " + eventName);
         let javaMap = objectToJavaMap(properties);
@@ -101,20 +138,36 @@ export function addEvent(eventName: string, properties?: object): void {
     }
 }
 export function addScreenAction(actionName: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Adding screen action: " + actionName);
     com.appsee.Appsee.addScreenAction(actionName);
 }
 
 /* Controlling video recording */
 export function stop(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Stopping Appsee video recording...");
     com.appsee.Appsee.stop();
 }
 export function pause(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Pausing Appsee video recording...");
     com.appsee.Appsee.pause();
 }
 export function resume(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Resuming Appsee video recording...");
     com.appsee.Appsee.resume();
 }
@@ -124,21 +177,37 @@ export function finishSession(
     verifyBackground: boolean,
     shouldUpload: boolean
 ): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Terminating current Appsee session");
     com.appsee.Appsee.finishSession(verifyBackground, shouldUpload);
 }
 export function forceNewSession(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Forcing intialization of new Appsee session");
     com.appsee.Appsee.forceNewSession();
 }
 
 export function upload(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Forcing upload of session");
     com.appsee.Appsee.upload();
 }
 
 /* Functions related to managing web views */
 export function installJavascriptInterface(wv: WebView): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Installing JavaScript interface in web view");
     com.appsee.Appsee.installJavascriptInterface(wv.android);
 }

--- a/src/appsee.ios.ts
+++ b/src/appsee.ios.ts
@@ -3,17 +3,22 @@ import { WebView } from "tns-core-modules/ui/web-view";
 import { View } from "tns-core-modules/ui/core/view";
 
 declare let Appsee: any;
+let packageExists = true;
+if (typeof Appsee === "undefined" || !Appsee) {
+    packageExists = false;
+    console.error("Appsee plugin is not installed correctly!!!");
+}
 
 /* Helper functions */
 function toIOSValue(jsValue: any) {
-    let returnVal = "null";
+    let returnVal: any = "null";
 
-    if(jsValue !== null) {
-        switch(typeof jsValue) {
-            case 'object':
+    if (jsValue !== null) {
+        switch (typeof jsValue) {
+            case "object":
                 returnVal = JSON.stringify(jsValue);
                 break;
-            case 'boolean':
+            case "boolean":
             case "number":
             case "string":
                 returnVal = jsValue;
@@ -30,14 +35,14 @@ function toIOSValue(jsValue: any) {
 function toNSDictionary(obj: object) {
     let iosDictionary = NSMutableDictionary.new();
 
-    for(const property in obj) {
-        if(obj.hasOwnProperty(property)) {
+    for (const property in obj) {
+        if (obj.hasOwnProperty(property)) {
             let value = obj[property];
 
-            if(value === null || value === undefined) {
-                 iosDictionary.setObjectForKey('null', property);
+            if (value === null || value === undefined) {
+                iosDictionary.setObjectForKey("null", property);
             } else {
-                 iosDictionary.setObjectForKey(toIOSValue(value), property);
+                iosDictionary.setObjectForKey(toIOSValue(value), property);
             }
         }
     }
@@ -47,40 +52,71 @@ function toNSDictionary(obj: object) {
 
 /* Starting and stopping Appsee monitoring */
 export function setDebug(log: boolean): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Enabling NSLog debugging for Appsee");
     Appsee.setDebugToNSLog(log);
 }
 export function start(apiKey: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Starting Appsee monitoring...");
     Appsee.start(apiKey);
 }
 
 /* Marking views as sensitive */
 export function markViewAsSensitive(view: View): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Marking view as sensitive in Appsee");
     Appsee.markViewAsSensitive(view.ios);
 }
 export function unmarkViewAsSensitive(view: View): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Unmarking view as sensitive in Appsee");
     Appsee.unmarkViewAsSensitive(view.ios);
 }
 
-
 /* Labeling events and views in Appsee */
 export function startScreen(screenName: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Starting Appsee screen: " + screenName);
     Appsee.startScreen(screenName);
 }
 export function setUserId(userId: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Setting user ID to: " + userId);
     Appsee.setUserId(userId);
 }
 export function setLocationDescription(description: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Setting location description: " + description);
     Appsee.setLocationDescription(description);
 }
 export function addEvent(eventName: string, properties?: object): void {
-    if(properties) {
+    if (!packageExists) {
+        return;
+    }
+
+    if (properties) {
         console.log("Adding event with properties: " + eventName);
         Appsee.addEventWithProperties(eventName, toNSDictionary(properties));
     } else {
@@ -89,42 +125,75 @@ export function addEvent(eventName: string, properties?: object): void {
     }
 }
 export function addScreenAction(actionName: string): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Adding screen action: " + actionName);
     Appsee.addScreenAction(actionName);
 }
 
-
 /* Controlling video recording */
 export function stop(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Stopping Appsee video recording...");
     Appsee.stop();
 }
 export function pause(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Pausing Appsee video recording...");
     Appsee.pause();
 }
 export function resume(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Resuming Appsee video recording...");
     Appsee.resume();
 }
 
-
 /* Appsee Session Management */
-export function finishSession(verifyBackground: boolean, shouldUpload: boolean): void {
+export function finishSession(
+    verifyBackground: boolean,
+    shouldUpload: boolean
+): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Terminating current Appsee session");
     Appsee.finishSession(verifyBackground, shouldUpload);
 }
 export function forceNewSession(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Forcing intialization of new Appsee session");
     Appsee.forceNewSession();
 }
 export function upload(): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Forcing upload of session");
     Appsee.upload();
 }
 
 /* Functions related to managing web views */
 export function installJavascriptInterface(wv: WebView): void {
+    if (!packageExists) {
+        return;
+    }
+
     console.log("Installing JavaScript interface in web view");
     Appsee.installJavascriptInterface(wv.ios);
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-appsee",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-appsee",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Integration for the Appsee analytics platform",
   "main": "appsee",
   "typings": "index.d.ts",

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Appsee'
+#pod 'Appsee'


### PR DESCRIPTION
  new developer guidelines for Analytic use
 On branch deprecate_appsee_ios
 Changes to be committed:
	modified:   src/appsee.android.ts
	modified:   src/appsee.ios.ts
	modified:   src/package-lock.json
	modified:   src/package.json
	modified:   src/platforms/ios/Podfile